### PR TITLE
feat/limited local storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ console.log(await capsule.getItem('shahata')); // logs 123
 
 ## LimitedLocalStorageStrategy
 
-Creates a local strategy pattern with strict rules, which could be overriden.
+Creates a local storage strategy pattern with strict rules, which could be overriden.
 The cleanup is being initiated when an item is being set. Otherwise no impact on local storage.
 
 ```js
@@ -84,12 +84,13 @@ import {DataCapsule, LimitedLocalStorageStrategy} from 'data-capsule';
 const strategy = new LimitedLocalStorageStrategy({
   expiration: 300, // default key expiration in seconds
   maxItems: 100,   // max items to store in local storage
-  maxAge: 300,     // items older than 5 minutes are disposed automatically,
+  maxAge: 300,     // items older than 5 minutes are disposed automatically
   timeout: 100     // how much the cleanup job should be delayed (in milliseconds)
 });
 
 const capsule = new DataCapsule({ namespace: 'wix', strategy });
-await capsule.setItem('1', 123); // By defaul the key will expire in 5 minutes
+await capsule.setItem('1', 123);                      // By defaul the key will expire in 5 minutes
+await capsule.setItem('2', 123, { expiration: 500 }); // Give a custom expiration time in seconds
 ```
 
 ## CachedStorage

--- a/README.md
+++ b/README.md
@@ -73,6 +73,25 @@ await capsule.setItem('shahata', 123);
 console.log(await capsule.getItem('shahata')); // logs 123
 ```
 
+## LimitedLocalStorageStrategy
+
+Creates a local strategy pattern with strict rules, which could be overriden.
+The cleanup is being initiated when an item is being set. Otherwise no impact on local storage.
+
+```js
+import {DataCapsule, LimitedLocalStorageStrategy} from 'data-capsule';
+
+const strategy = new LimitedLocalStorageStrategy({
+  expiration: 300, // default key expiration in seconds
+  maxItems: 100,   // max items to store in local storage
+  maxAge: 300,     // items older than 5 minutes are disposed automatically,
+  timeout: 100     // how much the cleanup job should be delayed (in milliseconds)
+});
+
+const capsule = new DataCapsule({ namespace: 'wix', strategy });
+await capsule.setItem('1', 123); // By defaul the key will expire in 5 minutes
+```
+
 ## CachedStorage
 
 Constructor accepts `options` object with `remoteStrategy` and `localStrategy`. Get operations are first tried against `localStrategy` and if no local cache exists, we then fallback to `remoteStrategy` ans eventually cache to `localStrategy`. Set operations are cached to `localStrategy` as well. Note that `localStrategy` cache is always set with expiration period of one hour in order to avoid stale cache issues. The `localStrategy` is `new LocalStorageStrategy()` bye default, so you don't have to pass it, but anyway you are better off using the short form below:

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 
 const FrameStorageListener = require('./utils/frame-storage-listener');
 const LocalStorageStrategy = require('./strategies/local-storage');
+const LimitedLocalStorageStrategy = require('./strategies/limited-local-storage');
 const FrameStorageStrategy = require('./strategies/frame-storage');
 const WixStorageStrategy = require('./strategies/wix-storage');
 const CachedStorageStrategy = require('./strategies/cached-storage');
@@ -26,6 +27,7 @@ module.exports = {
   FrameStorageListener,
   FrameStorageStrategy,
   LocalStorageStrategy,
+  LimitedLocalStorageStrategy,
   LocalStorageCapsule,
   WixStorageStrategy,
   CachedStorageStrategy,

--- a/src/strategies/limited-local-storage.js
+++ b/src/strategies/limited-local-storage.js
@@ -1,0 +1,38 @@
+const {clean, isExpired} = require('../utils/local-storage-cleaner');
+const LocalStorageStrategy = require('./local-storage');
+
+const FIVE_MINUTES = 60 * 5;
+
+class LimitedLocalStorageStrategy extends LocalStorageStrategy {
+
+  constructor(args = {}) {
+    super();
+
+    this.expiration = args.expiration || FIVE_MINUTES;
+    this.maxAge = args.maxAge || FIVE_MINUTES;
+    this.maxItems = args.maxItems || 100;
+    this.timeout = args.timeout || 100;
+  }
+
+  setItem(key, value, options) {
+    const {expiration} = this;
+    return this._cleanup(super.setItem(key, value, Object.assign({expiration}, options)));
+  }
+
+  _cleanup(promise) {
+    clearTimeout(this.scheduledCleaner);
+    this.scheduledCleaner = setTimeout(() => {
+      const now = Date.now();
+      clean((record, remaining) => {
+        if (isExpired(record) || (record.createdAt + (this.maxAge * 1000) < now) || (remaining > this.maxItems)) {
+          return true;
+        }
+        return false;
+      });
+    }, this.timeout);
+    return promise;
+  }
+
+}
+
+module.exports = LimitedLocalStorageStrategy;

--- a/src/strategies/local-storage.js
+++ b/src/strategies/local-storage.js
@@ -2,7 +2,7 @@
 'use strict';
 
 const BaseStorage = require('../base-storage');
-const localStorageCleaner = require('../utils/local-storage-cleaner');
+const {localStorageCleaner} = require('../utils/local-storage-cleaner');
 const {STORAGE_PREFIX, PREFIX_SEPARATOR, KEY_SEPARATOR, NOT_FOUND} = require('../utils/constants');
 const {getCacheRecords, deserializeData, isExpired} = require('../utils/record-utils');
 

--- a/src/utils/local-storage-cleaner.js
+++ b/src/utils/local-storage-cleaner.js
@@ -40,4 +40,19 @@ function localStorageCleaner(requiredSpace) {
   deleteOld(cleaner);
 }
 
-module.exports = localStorageCleaner;
+function clean(condition) {
+  const records = getCacheRecords().sort(createdAtSort);
+  return records.reduce((acc, curr) => {
+    if (condition(curr, records.length - acc.length)) {
+      localStorage.removeItem(curr.originalKey);
+      return acc.concat(curr.originalKey);
+    }
+    return acc;
+  }, []);
+}
+
+module.exports = {
+  localStorageCleaner,
+  isExpired,
+  clean
+};

--- a/test/strategies/limited-local-storage.spec.js
+++ b/test/strategies/limited-local-storage.spec.js
@@ -1,0 +1,92 @@
+const sinon = require('sinon');
+const {expect} = require('chai');
+const {LocalStorage} = require('node-localstorage');
+
+const {
+  NOT_FOUND,
+  DataCapsule,
+  LimitedLocalStorageStrategy
+} = require('../../src');
+
+describe('LimitedLocalStorage strategy', () => {
+
+  let clock;
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers(Date.now());
+    global.localStorage = new LocalStorage('./limited-local-storage');
+  });
+
+  afterEach(() => {
+    clock.restore();
+    global.localStorage.clear();
+  });
+
+  describe('default expiration', () => {
+
+    it('should allow setting and getting the item', async () => {
+      const capsule = new DataCapsule({namespace: 'wix', strategy: new LimitedLocalStorageStrategy()});
+      await capsule.setItem('test', 123);
+      expect(await capsule.getItem('test')).to.equal(123);
+    });
+
+    it('should give a default 5 minutes expiration for each value set', async () => {
+      const capsule = new DataCapsule({namespace: 'wix', strategy: new LimitedLocalStorageStrategy()});
+      await capsule.setItem('test', 123);
+      clock.tick(1000 * 60 * 5);
+      await expect(capsule.getItem('test')).to.be.rejectedWith(NOT_FOUND);
+    });
+
+    it('should schedule the cleanup process upon setting the new item', async () => {
+      const capsule = new DataCapsule({namespace: 'wix', strategy: new LimitedLocalStorageStrategy()});
+      await capsule.setItem('1', 1);
+      await capsule.setItem('2', 2);
+      expect(liveKeys()).to.deep.equal(['capsule|wix#1', 'capsule|wix#2']);
+      clock.tick(1000 * 60 * 5);
+      await capsule.setItem('3', 3, {expiration: 400});
+      await timeout(100);
+      expect(liveKeys()).to.deep.equal(['capsule|wix#3']);
+    });
+
+    it('should clean old items an leave max items allowed', async () => {
+      const strategy = new LimitedLocalStorageStrategy({maxItems: 2});
+      const capsule = new DataCapsule({namespace: 'wix', strategy});
+      await capsule.setItem('1', 1);
+      clock.tick(1);
+      await capsule.setItem('2', 2);
+      clock.tick(2);
+      await capsule.setItem('3', 3);
+      await timeout(100);
+      expect(liveKeys()).to.deep.equal(['capsule|wix#2', 'capsule|wix#3']);
+    });
+
+    it('should clean old items and leave ones with valid age', async () => {
+      const strategy = new LimitedLocalStorageStrategy({maxAge: 1});
+      const capsule = new DataCapsule({namespace: 'wix', strategy});
+      await capsule.setItem('1', 1);
+      clock.tick(1000);
+      await capsule.setItem('2', 2);
+      clock.tick(1000);
+      await capsule.setItem('3', 3);
+      await timeout(100);
+      expect(liveKeys()).to.deep.equal(['capsule|wix#3']);
+    });
+
+  });
+
+  function liveKeys() {
+    const result = [];
+    for (let i = 0; i < global.localStorage.length; i++) {
+      result.push(global.localStorage.key(i));
+    }
+    return result.sort();
+  }
+
+  function timeout(ms) {
+    return new Promise(resolve => {
+      setTimeout(() => resolve(), ms);
+      clock.tick(ms);
+    });
+  }
+
+});


### PR DESCRIPTION
Add a limited version of `LocalStorageStrategy` implementation.

Key features:
* Gives a default expiration for any key set to `5 mins`
* Allows to store up to `100 maxItems` at the same time
* All items older than `5 minutes` by default will be disposed
* The cleanup process is being delayed by `100 ms` to avoid blocking the main functionality