### PR TITLE
decrease bundle size

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
   },
   "dependencies": {
     "axios": "^0.15.3",
-    "babel-runtime": "^6.20.0",
     "greedy-split": "^1.0.0"
   },
   "private": false,
   "devDependencies": {
+    "babel-runtime": "^6.20.0",
     "babel-plugin-transform-runtime": "^6.15.0",
     "babel-preset-env": "^1.1.8",
     "babel-preset-stage-0": "^6.5.0",
@@ -38,11 +38,11 @@
     "yoshi": "latest"
   },
   "babel": {
-    "plugins": [
-      "transform-runtime"
-    ],
     "env": {
       "test": {
+        "plugins": [
+          "transform-runtime"
+        ],
         "presets": [
           "stage-0",
           [
@@ -83,7 +83,8 @@
   "yoshi": {
     "entry": {
       "index": "./global.js",
-      "frame": "./frame.js"
+      "frame": "./frame.js",
+      "frame-listener": "./global-frame-listener"
     }
   }
 }

--- a/src/frame-listener.js
+++ b/src/frame-listener.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const FrameStorageListener = require('./utils/frame-storage-listener');
+const LocalStorageStrategy = require('./strategies/local-storage');
+const {NOT_FOUND} = require('./utils/constants');
+const BaseStorage = require('./base-storage');
+const DataCapsule = require('./data-capsule');
+
+module.exports = {
+  NOT_FOUND,
+  BaseStorage,
+  DataCapsule,
+  LocalStorageStrategy,
+  FrameStorageListener,
+};

--- a/src/global-frame-listener.js
+++ b/src/global-frame-listener.js
@@ -1,0 +1,4 @@
+/* global window */
+'use strict';
+
+window.DataCapsuleTools = require('./frame-listener');

--- a/src/utils/frame-storage-listener.js
+++ b/src/utils/frame-storage-listener.js
@@ -12,9 +12,6 @@ class FrameStorageListener {
   }
 
   start(verifier) {
-    // if (this._listener) {
-    //   return;
-    // }
     const storageStrategy = BaseStorage.verify(this.storageStrategy);
     this._listener = e => {
       const [target, token, id, method, params] = greedySplit(e.data, '|', 5);

--- a/src/utils/frame-storage-listener.js
+++ b/src/utils/frame-storage-listener.js
@@ -16,7 +16,7 @@ class FrameStorageListener {
     //   return;
     // }
     const storageStrategy = BaseStorage.verify(this.storageStrategy);
-    this._listener = async e => {
+    this._listener = e => {
       const [target, token, id, method, params] = greedySplit(e.data, '|', 5);
       const respond = (method, param) => {
         const message = [target + 'Done', token, id, method, JSON.stringify(param)].join('|');
@@ -25,13 +25,15 @@ class FrameStorageListener {
 
       if (target === STORAGE_PREFIX && verifier(e.source, e.origin, token)) {
         const invoke = storageStrategy[method].bind(storageStrategy);
-        try {
-          respond('resolve', await invoke(...JSON.parse(params)));
-        } catch (reason) {
+        invoke(...JSON.parse(params))
+        .then(result => {
+          respond('resolve', result);
+        }).catch(reason => {
           respond('reject', reason.message || reason);
-        }
+        });
       }
     };
+
     window.addEventListener('message', this._listener);
   }
 

--- a/test/strategies/frame-storage.spec.js
+++ b/test/strategies/frame-storage.spec.js
@@ -54,13 +54,13 @@ describe.jsdom('frame-storage-strategy with custom host strategy', () => {
 
   class MyStorageStrategy extends BaseStorage {
     setItem() {
-      throw new Error('byebye');
+      return Promise.reject(new Error('byebye'));
     }
     getItem() {
-      throw 'byebye';
+      return Promise.reject('byebye');
     }
     removeItem() {
-      throw {bye: 'bye'};
+      return Promise.reject({bye: 'bye'});
     }
     getAllItems() {
       //


### PR DESCRIPTION
We needed to make this library smaller, so we decided to remove babel-runtime and use native promises instead.

1. Made babel-runtime a devDependency. (we still use async functions in our tests)
2. Remove all async functions from production code.
3. Created another bundle for frame listener which has the bare minimum it needs (weights 3kb).