### PR TITLE
upgrade axios to 0.18.X

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "release": "yoshi release; bower-auto-release --dist dist/statics"
   },
   "dependencies": {
-    "axios": "^0.16.2",
+    "axios": "^0.18.0",
     "greedy-split": "^1.0.0",
     "message-channel": "^2.0.0"
   },


### PR DESCRIPTION
Upgrade to a more updated version of axios. Not upgrading to 0.19.0 because it was just recently released.