### PR TITLE
axios version to be a range

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "release": "yoshi release; bower-auto-release --dist dist/statics"
   },
   "dependencies": {
-    "axios": "^0.16.2",
+    "axios": ">=0.16 <=0.19",
     "greedy-split": "^1.0.0",
     "message-channel": "^2.0.0"
   },


### PR DESCRIPTION
Allow deduplication for projects that use higher axios version. Axios manages breaking changes on minor as well, that's why I couldn't use `^0.x`.