### PR TITLE
reject when access is denied for localStorage

### DIFF
--- a/src/strategies/local-storage.js
+++ b/src/strategies/local-storage.js
@@ -3,7 +3,7 @@
 
 const BaseStorage = require('../base-storage');
 const localStorageCleaner = require('../utils/local-storage-cleaner');
-const {STORAGE_PREFIX, PREFIX_SEPARATOR, KEY_SEPARATOR, NOT_FOUND} = require('../utils/constants');
+const {STORAGE_PREFIX, PREFIX_SEPARATOR, KEY_SEPARATOR, NOT_FOUND, LOCAL_STORAGE_UNSUPPORTED} = require('../utils/constants');
 const {getCacheRecords, deserializeData, isExpired} = require('../utils/record-utils');
 
 function getCacheKey(key, options) {
@@ -49,7 +49,12 @@ class LocalStorageStrategy extends BaseStorage {
 
   getItem(key, options) {
     const fullKey = getCacheKey(key, options);
-    let data = localStorage.getItem(fullKey);
+    let data;
+    try {
+      data = localStorage.getItem(fullKey);
+    } catch (e) {
+      return Promise.reject(LOCAL_STORAGE_UNSUPPORTED);
+    }
     data = data && deserializeData(data);
     if (data && !isExpired(data)) {
       updateAccessTime(fullKey, data);

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,6 +1,7 @@
 const errors = {
   NOT_FOUND: new Error('Key was not found in capsule'),
-  SERVER_ERROR: new Error('Failed to perform operarion on server')
+  SERVER_ERROR: new Error('Failed to perform operarion on server'),
+  LOCAL_STORAGE_UNSUPPORTED: new Error('LocalStorage is not supported')
 };
 
 function toError(str) {
@@ -18,4 +19,5 @@ module.exports = {
   MESSAGE_MAX_TIMEOUT: 8000,
   SERVER_ERROR: errors.SERVER_ERROR,
   toError,
+  LOCAL_STORAGE_UNSUPPORTED: errors.LOCAL_STORAGE_UNSUPPORTED,
 };

--- a/test/strategies/local-storage.spec.js
+++ b/test/strategies/local-storage.spec.js
@@ -3,7 +3,7 @@
 const sinon = require('sinon');
 const {expect} = require('chai');
 const {LocalStorage} = require('node-localstorage');
-const {NOT_FOUND, LocalStorageCapsule} = require('../../src');
+const {NOT_FOUND, LocalStorageCapsule, LOCAL_STORAGE_UNSUPPORTED} = require('../../src');
 
 describe('localstorage-strategy', () => {
   beforeEach(() => {
@@ -11,7 +11,7 @@ describe('localstorage-strategy', () => {
   });
 
   afterEach(() => {
-    global.localStorage.clear();
+    global.localStorage && global.localStorage.clear();
   });
 
   it('should store and retrieve information', async () => {
@@ -135,5 +135,11 @@ describe('localstorage-strategy', () => {
     const capsule = new LocalStorageCapsule({namespace: 'wix'});
     await capsule.setItem('shahata', 1, {scope: {userId: 123}});
     expect(await capsule.getAllItems({scope: {userId: 123}})).to.eql({shahata: 1});
+  });
+
+  it('should reject if get from local storage fails', async () => {
+    const capsule = new LocalStorageCapsule({namespace: 'wix'});
+    global.localStorage = undefined;
+    await expect(capsule.getItem('shahata')).to.be.rejectedWith(LOCAL_STORAGE_UNSUPPORTED);
   });
 });


### PR DESCRIPTION
We assumed that FrameStorageListener always runs in parent, and will be able to always use localStorage, but apparently some users run their Wix site in an iframe in some other site, and localStorage might be disabled for third parties (iframes). In addition, browsers have an option to turn off cookies and localStorage even for the parent.
Currently, in this scenario, `localStorage.get` throws with `Failed to read the 'localStorage' property from 'Window': Access is denied for this document.`, but the code expects a promise to be rejected, so I returned a rejected promise.