### PR TITLE
Add optional category to SetOptions

### DIFF
--- a/src/typings/index.d.ts
+++ b/src/typings/index.d.ts
@@ -10,6 +10,7 @@ export interface ConstructorOptions extends Options {
 
 export interface SetOptions extends Options {
   expiration?: number;
+  category?: 'essential' | 'functional' | 'analytics' | 'advertising'
 }
 
 export class BaseStorage {


### PR DESCRIPTION
`SetOptions` is missing `category` https://github.com/wix/data-capsule/blob/396696fc1c14aae415f1ffc3d32abc5a59a28345/src/typings/index.d.ts#L12
which is used by LocalStorageStrategy: https://github.com/wix/data-capsule/blob/396696fc1c14aae415f1ffc3d32abc5a59a28345/src/strategies/local-storage.js#L58