### PR TITLE
Removing tslib

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
   "dependencies": {
     "axios": "^0.19.2",
     "greedy-split": "^1.0.0",
-    "message-channel": "^2.0.0",
-    "tslib": "^2.0.0"
+    "message-channel": "^2.0.0"
   },
   "private": false,
   "devDependencies": {


### PR DESCRIPTION
## performance optimization

We added a feature to [dumbledore](https://bo.wix.com/dumbledore) that shows bundles diff between versions.
I wanted to test so I searched for a [big diff](https://bo.wix.com/dumbledore/history?artifactId=com.wixpress.wix-ecommerce-storemanager&type=client) in bundle size
![image](https://user-images.githubusercontent.com/2688676/100745922-a6468200-33e8-11eb-8e2b-aa76dcc9d781.png)
So I used the feature to see [what changed](https://bo.wix.com/dumbledore/static?artifactId=com.wixpress.wix-ecommerce-storemanager&type=client&version=1.3009.0&baseline=1.3008.0)
And here you can see lot's of changes but one of them is that they have another version of `tslib` in their bundle (which makes it 2) 
![image](https://user-images.githubusercontent.com/2688676/100748457-025ed580-33ec-11eb-9bbd-a75f96080881.png)
and using [qnm](https://github.com/ranyitz/qnm) it shows that the second version comes from this package.

It was added here #52 and aligns with the timeline of the bundles, I don't see a reason to add it as a dependency since typescript adds it if needed
