### PR TITLE
Bump axios to `^0.21.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "postpublish": "bower-auto-release --dist dist/statics"
   },
   "dependencies": {
-    "axios": "^0.19.2",
+    "axios": "^0.21.0",
     "greedy-split": "^1.0.0",
     "message-channel": "^2.0.0",
     "tslib": "^2.0.0"


### PR DESCRIPTION
Align the version with https://github.com/wix-private/metro/blob/master/packages/http-client/package.json#L89

So webpack not to bundle 2 different versions on projects that use both libraries